### PR TITLE
chore(erigon-revert): reverting to v2022.10.01 erigon due to bug

### DIFF
--- a/helmfiles/templates/eth-goerli.yaml
+++ b/helmfiles/templates/eth-goerli.yaml
@@ -12,7 +12,7 @@ templates:
   launchpad-release-template-erigon-eth-goerli: &launchpad-release-template-erigon-eth-goerli
     <<: *launchpad-release-template-defaults
     chart: graphops/erigon
-    version: 0.3.6
+    version: 0.3.5
 
   launchpad-release-template-nimbus-eth-goerli: &launchpad-release-template-nimbus-eth-goerli
     <<: *launchpad-release-template-defaults


### PR DESCRIPTION
see issue here https://github.com/ledgerwatch/erigon/issues/5663