### PR TITLE
bug: update `cd` cmd for k9s step

### DIFF
--- a/taskfiles/launchpad_deps_linux.yml
+++ b/taskfiles/launchpad_deps_linux.yml
@@ -80,7 +80,7 @@ tasks:
     interactive: true
     cmds:
       - |
-        cd $(mktemp)
+        cd $(mktemp -d)
         wget https://github.com/derailed/k9s/releases/download/v{{.K9S_VERSION}}/k9s_Linux_x86_64.tar.gz
         tar xfz k9s_Linux_x86_64.tar.gz
         mv k9s /usr/local/bin


### PR DESCRIPTION
Add `-d` flag to specify `mktemp` is a directory and not a file